### PR TITLE
Use HWC Buildpack instead of binary buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Push the app with no-start:
 ```
-cf push environment -s windows2012R2 -b binary_buildpack --no-start -p ./ViewEnvironment/
+cf push environment -s windows2012R2 -b hwc_buildpack --no-start -p ./ViewEnvironment/
 ```
 
 If Diego is enabled by default on your CF deployment, you can omit the `--no-start` flag.


### PR DESCRIPTION
Otherwise the app won't start.

2017-08-23T15:47:52.42+0800 [APP/PROC/WEB/0] ERR Warning: We detected a Web.config in your app. This probably means t
hat you want to use the hwc-buildpack. If you really want to use the binary-buildpack, you must specify a start command.